### PR TITLE
Do not bind TCP sockets to a specific local port. Consume all messages in a read off the socket

### DIFF
--- a/parser/parser_stream.go
+++ b/parser/parser_stream.go
@@ -164,6 +164,12 @@ func (p *ParserStream) ParseSIPStream(data []byte) (msg sip.Message, err error) 
 	}(reader)
 
 	switch err {
+	case nil:
+		reader.Reset()
+		reader.Write(unparsed)
+		p.state = stateStartLine
+		p.msg = nil
+		return msg, err
 	case ErrParseLineNoCRLF, ErrParseReadBodyIncomplete:
 		reader.Reset()
 		reader.Write(unparsed)

--- a/sip/headers.go
+++ b/sip/headers.go
@@ -236,7 +236,7 @@ func (hs *headers) RemoveHeader(name string) (removed bool) {
 		}
 	}
 
-	removed = foundIdx > 0
+	removed = foundIdx >= 0
 	// Update refs
 	if removed {
 		for _, entry := range hs.headerOrder[foundIdx:] {

--- a/transport/tcp.go
+++ b/transport/tcp.go
@@ -85,19 +85,12 @@ func (t *TCPTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.Mess
 	// if err != nil {
 	// 	return nil, err
 	// }
-	var tladdr *net.TCPAddr = nil
-	if laddr.IP != nil {
-		tladdr = &net.TCPAddr{
-			IP:   laddr.IP,
-			Port: laddr.Port,
-		}
-	}
 
 	traddr := &net.TCPAddr{
 		IP:   raddr.IP,
 		Port: raddr.Port,
 	}
-	return t.createConnection(tladdr, traddr, handler)
+	return t.createConnection(nil, traddr, handler)
 }
 
 func (t *TCPTransport) createConnection(laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {

--- a/transport/tcp.go
+++ b/transport/tcp.go
@@ -171,18 +171,21 @@ func (t *TCPTransport) readConnection(conn *TCPConnection, raddr string, handler
 }
 
 func (t *TCPTransport) parseStream(par *parser.ParserStream, data []byte, src string, handler sip.MessageHandler) {
-	msg, err := par.ParseSIPStream(data)
-	if err == parser.ErrParseSipPartial {
-		return
-	}
-	if err != nil {
-		t.log.Error("failed to parse", "err", err, "data", string(data))
-		return
-	}
+	for {
+		msg, err := par.ParseSIPStream(data)
+		if err == parser.ErrParseSipPartial {
+			return
+		}
+		if err != nil {
+			t.log.Error("failed to parse", "err", err, "data", string(data))
+			return
+		}
 
-	msg.SetTransport(t.Network())
-	msg.SetSource(src)
-	handler(msg)
+		msg.SetTransport(t.Network())
+		msg.SetSource(src)
+		handler(msg)
+		data = nil
+	}
 }
 
 // TODO use this when message size limit is defined


### PR DESCRIPTION
This PR:
- lets the OS network stack decide what interface/local port to use when binding the local socket when initiating a TCP connection to a remote SIP server. This is needed because sipgo uses the Via header in some flows to determine the local address to use. This can work for UDP, but will fail for TCP as it will attempt to reuse the port on which there server is listening for TCP connections to accept
- handles the case where more than 1 SIP message is returned in a single read off the socket, over TCP.
- fixes a index test in `RemoveHeader` when determining if a header was found