### PR TITLE
fix: bump emiago/sipgo to v1.4.0 for IPv6 Via parsing fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.5
 
 require (
-	github.com/emiago/sipgo v1.2.1
+	github.com/emiago/sipgo v1.4.0
 	github.com/gobwas/ws v1.4.0
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/emiago/sipgo v1.2.1 h1:5JTwogbe3yQFA3sjBVueN2Q4WTU350tGeBwPYT8HMv0=
-github.com/emiago/sipgo v1.2.1/go.mod h1:DuwAxBZhKMqIzQFPGZb1MVAGU6Wuxj64oTOhd5dx/FY=
+github.com/emiago/sipgo v1.4.0 h1:IRiwIUu4H97gC+vq2zsm3iWe/j08LPExFZRe3kfY0f0=
+github.com/emiago/sipgo v1.4.0/go.mod h1:DuwAxBZhKMqIzQFPGZb1MVAGU6Wuxj64oTOhd5dx/FY=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/sip/via_ipv6_test.go
+++ b/sip/via_ipv6_test.go
@@ -1,0 +1,49 @@
+package sip
+
+import (
+	"testing"
+
+	sipgo "github.com/emiago/sipgo/sip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseViaIPv6Issue640 is a regression test for livekit/sip#640: inbound
+// IPv6 INVITEs (UDP and TCP) were silently dropped because the Via parser
+// mistook the inner colons of a bracketed IPv6 host literal for the host:port
+// separator. The fix lives in emiago/sipgo's parse_via.go and is pulled in via
+// the dependency bump; this test guards against a future downgrade.
+func TestParseViaIPv6Issue640(t *testing.T) {
+	cases := []struct {
+		name     string
+		via      string
+		wantHost string
+		wantPort int
+	}{
+		{"bracketed IPv6 with port", "SIP/2.0/UDP [2001:db8::1]:5060;branch=z9hG4bKabc", "2001:db8::1", 5060},
+		{"bracketed IPv6 without port", "SIP/2.0/UDP [2001:db8::1];branch=z9hG4bKabc", "2001:db8::1", 0},
+		{"loopback ::1", "SIP/2.0/UDP [::1];branch=z9hG4bKabc", "::1", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := "INVITE sip:bob@example.com SIP/2.0\r\n" +
+				"Via: " + tc.via + "\r\n" +
+				"From: <sip:alice@example.com>;tag=1\r\n" +
+				"To: <sip:bob@example.com>\r\n" +
+				"Call-ID: test-640\r\n" +
+				"CSeq: 1 INVITE\r\n" +
+				"Content-Length: 0\r\n\r\n"
+
+			msg, err := sipgo.NewParser().ParseSIP([]byte(raw))
+			require.NoError(t, err)
+
+			req, ok := msg.(*Request)
+			require.True(t, ok)
+
+			via := req.Via()
+			require.NotNil(t, via)
+			assert.Equal(t, tc.wantHost, via.Host)
+			assert.Equal(t, tc.wantPort, via.Port)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Bumps `emiago/sipgo` v1.2.1 → v1.4.0. The critical fix is bracket-aware Via header parsing (emiago/sipgo#300): inbound SIP from IPv6 peers previously failed with `strconv.Atoi: parsing "...:b0c:5::192]:5060": invalid syntax` because inner colons of a bracketed IPv6 host literal were mistaken for the host:port separator, silently dropping all calls from IPv6 peers.

No API changes required — v1.2.1 → v1.4.0 is a minor bump.

Regression test added in `sip/via_ipv6_test.go` covering bracketed IPv6 with/without port and the `::1` loopback case.

Once merged, livekit/sip will need a corresponding bump of this package to pick up the fix for livekit/sip#640.

## Related

- Supersedes #7, #8, #9 (previous attempts targeting wrong base branch or including excess scope)
- Required by livekit/sip#640